### PR TITLE
Fix #4 : Build with Java-9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ target
 *.iml
 .DS_Store
 *.idea
+.settings
+.classpath
+.project
+dependency-reduced-pom.xml

--- a/crawler-cleanup/pom.xml
+++ b/crawler-cleanup/pom.xml
@@ -86,7 +86,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>2.6</version>
         <configuration>
           <finalName>crawler-cleanup</finalName>
         </configuration>

--- a/crawler-ws/pom.xml
+++ b/crawler-ws/pom.xml
@@ -20,7 +20,6 @@
 
   <properties>
     <servlet-api.version>3.1.0</servlet-api.version>
-    <maven-shade-plugin.version>2.4</maven-shade-plugin.version>
   </properties>
 
   <build>
@@ -39,7 +38,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>${maven-shade-plugin.version}</version>
         <executions>
           <execution>
             <phase>package</phase>

--- a/crawler/src/test/java/org/gbif/crawler/CrawlerTest.java
+++ b/crawler/src/test/java/org/gbif/crawler/CrawlerTest.java
@@ -113,9 +113,6 @@ public class CrawlerTest {
 
   @Test
   public void testAbortFatalCrawlException() throws Exception {
-    when(responseHandler.isEndOfRecords()).thenReturn(Optional.<Boolean>absent());
-    when(responseHandler.getRecordCount()).thenReturn(Optional.<Integer>absent());
-    when(responseHandler.getContentHash()).thenReturn(Optional.<Long>absent());
     when(client.execute(anyString(), eq(responseHandler))).thenThrow(new FatalCrawlException("foo"));
     crawler.crawl();
     verify(client, times(1)).execute(anyString(), eq(responseHandler));

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.gbif</groupId>
     <artifactId>motherpom</artifactId>
-    <version>37</version>
+    <version>38-SNAPSHOT</version>
   </parent>
 
   <groupId>org.gbif.crawler</groupId>
@@ -68,7 +68,7 @@
     <junit.version>4.12</junit.version>
     <logback.version>1.1.7</logback.version>
     <metainf-services.version>1.7</metainf-services.version>
-    <mockito.version>1.9.5</mockito.version>
+    <mockito.version>2.8.9</mockito.version>
     <slf4j.version>1.7.21</slf4j.version>
     <stax.version>1.0-2</stax.version>
     <stax2.version>4.0.0</stax2.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.gbif</groupId>
     <artifactId>motherpom</artifactId>
-    <version>38-SNAPSHOT</version>
+    <version>37</version>
   </parent>
 
   <groupId>org.gbif.crawler</groupId>


### PR DESCRIPTION
Minor changes necessary to build with Java-9.

One test change required because it had declared Mockito statements that were not actually being used, and the updated Mockito version failed because of that.

Also removed versions for two plugins which now have their versions specified in motherpom-38-SNAPSHOT and do not need them redeclared here. In the case of maven-jar-plugin, the declared version here prevented building with Java-9.