### PR TITLE
fix(download): Handling of concurrent fetching of target file

### DIFF
--- a/crawler-cli/src/main/java/org/gbif/crawler/common/DownloadCrawlConsumer.java
+++ b/crawler-cli/src/main/java/org/gbif/crawler/common/DownloadCrawlConsumer.java
@@ -25,6 +25,7 @@ import org.gbif.utils.HttpUtil;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.util.UUID;
 
@@ -64,20 +65,20 @@ public abstract class DownloadCrawlConsumer extends CrawlConsumer {
   private final HttpClient client;
 
   public DownloadCrawlConsumer(
-      CuratorFramework curator,
-      MessagePublisher publisher,
-      File archiveRepository,
-      int httpTimeout) {
+    CuratorFramework curator,
+    MessagePublisher publisher,
+    File archiveRepository,
+    int httpTimeout) {
     super(curator, publisher);
     this.archiveRepository = archiveRepository;
     if (!archiveRepository.exists() || !archiveRepository.isDirectory()) {
       throw new IllegalArgumentException(
-          "Archive repository needs to be an existing directory: "
-              + archiveRepository.getAbsolutePath());
+        "Archive repository needs to be an existing directory: "
+        + archiveRepository.getAbsolutePath());
     }
     if (!archiveRepository.canWrite()) {
       throw new IllegalArgumentException(
-          "Archive repository directory not writable: " + archiveRepository.getAbsolutePath());
+        "Archive repository directory not writable: " + archiveRepository.getAbsolutePath());
     }
 
     client = HttpUtil.newMultithreadedClient(httpTimeout, 25, 2);
@@ -102,43 +103,43 @@ public abstract class DownloadCrawlConsumer extends CrawlConsumer {
     final File localFile = new File(datasetDirectory, datasetKey + getSuffix());
 
     try (MDC.MDCCloseable ignored1 = MDC.putCloseable("datasetKey", datasetKey.toString());
-        MDC.MDCCloseable ignored2 =
-            MDC.putCloseable("attempt", String.valueOf(crawlJob.getAttempt()))) {
+         MDC.MDCCloseable ignored2 =
+           MDC.putCloseable("attempt", String.valueOf(crawlJob.getAttempt()))) {
       // Sub-try so the MDC is still present for the exception logging.
       try {
         LOG.info("Start download of archive from {} to {}", crawlJob.getTargetUrl(), localFile);
         StatusLine status =
-            client.downloadIfModifiedSince(crawlJob.getTargetUrl().toURL(), null, localFile, true);
+          client.downloadIfModifiedSince(crawlJob.getTargetUrl().toURL(), null, localFile, true);
 
         if (status.getStatusCode() == HttpStatus.SC_NOT_MODIFIED) {
-          Files.createLink(
-              new File(datasetDirectory, datasetKey + "." + crawlJob.getAttempt() + getSuffix())
-                  .toPath(),
-              localFile.toPath());
-          notModified(datasetKey);
+          if (linkAttemptFile(datasetDirectory, datasetKey, crawlJob, localFile)) {
+            notModified(datasetKey);
+          } else {
+            duplicateAttempt(datasetKey, crawlJob);
+          }
         } else if (HttpUtil.success(status)) {
-          Files.createLink(
-              new File(datasetDirectory, datasetKey + "." + crawlJob.getAttempt() + getSuffix())
-                  .toPath(),
-              localFile.toPath());
-          afterSuccessfulDownload(datasetKey, crawlJob, localFile);
-          success(datasetKey, crawlJob);
+          if (linkAttemptFile(datasetDirectory, datasetKey, crawlJob, localFile)) {
+            afterSuccessfulDownload(datasetKey, crawlJob, localFile);
+            success(datasetKey, crawlJob);
+          } else {
+            duplicateAttempt(datasetKey, crawlJob);
+          }
         } else {
           failed(datasetKey);
           throw new IllegalStateException(
-              "HTTP "
-                  + status.getStatusCode()
-                  + ". Failed to download archive for dataset "
-                  + datasetKey
-                  + " from "
-                  + crawlJob.getTargetUrl());
+            "HTTP "
+            + status.getStatusCode()
+            + ". Failed to download archive for dataset "
+            + datasetKey
+            + " from "
+            + crawlJob.getTargetUrl());
         }
       } catch (IOException e) {
         LOG.error(
-            "Failed to download archive for dataset [{}] from [{}]",
-            crawlJob.getDatasetKey(),
-            crawlJob.getTargetUrl(),
-            e);
+          "Failed to download archive for dataset [{}] from [{}]",
+          crawlJob.getDatasetKey(),
+          crawlJob.getTargetUrl(),
+          e);
         failed(datasetKey);
         throw new RuntimeException(e);
 
@@ -147,6 +148,55 @@ public abstract class DownloadCrawlConsumer extends CrawlConsumer {
         updateDate(curator, datasetKey, CrawlerNodePaths.FINISHED_CRAWLING);
       }
     }
+  }
+
+  /**
+   * Links the just-downloaded archive to its attempt-numbered file name (e.g.
+   * {@code datasetKey.attempt.dwcdp}).
+   *
+   * @return true if a new link was created; false if the attempt file already existed, meaning
+   *     this crawl attempt was already processed concurrently (e.g. a duplicate queue message,
+   *     or two runs racing each other) - the caller must not proceed to trigger downstream
+   *     processing again in that case, see {@link #duplicateAttempt(UUID, CrawlJob)}.
+   */
+  boolean linkAttemptFile(File datasetDirectory, UUID datasetKey, CrawlJob crawlJob, File localFile)
+    throws IOException {
+    File attemptFile =
+      new File(datasetDirectory, datasetKey + "." + crawlJob.getAttempt() + getSuffix());
+    try {
+      Files.createLink(attemptFile.toPath(), localFile.toPath());
+      return true;
+    } catch (FileAlreadyExistsException e) {
+      LOG.warn(
+        "Attempt file [{}] for dataset [{}] attempt [{}] already exists - this attempt was "
+        + "likely already processed concurrently (e.g. a duplicate queue message)",
+        attemptFile, datasetKey, crawlJob.getAttempt());
+      return false;
+    }
+  }
+
+  /**
+   * Called when this crawl attempt turns out to be a duplicate of one already processed
+   * concurrently (see {@link #linkAttemptFile}). We still mark the crawl as finished in
+   * ZooKeeper so nothing is left dangling, but deliberately do NOT call {@link #success} or
+   * {@link #notModified}: both publish a "download finished" message, and the other, already-
+   * completed run for this same attempt will (or already did) publish its own - sending a second
+   * one here would cause this attempt to run through the full downstream pipeline twice.
+   *
+   * <p>We also deliberately do NOT write {@link CrawlerNodePaths#FINISHED_REASON} here: we can't
+   * tell whether this run is racing ahead of or behind the genuine run for this attempt, so
+   * writing e.g. {@code ABORT} risks overwriting the correct {@code NORMAL}/{@code NOT_MODIFIED}
+   * the other run sets - in either order. Leaving it alone means whichever run actually completed
+   * the real work gets to record why it finished.
+   */
+  protected void duplicateAttempt(UUID datasetKey, CrawlJob crawlJob) {
+    LOG.warn(
+      "Dataset [{}] attempt [{}] was already processed concurrently; marking finished without "
+      + "triggering downstream processing again",
+      datasetKey, crawlJob.getAttempt());
+    createOrUpdate(curator, datasetKey, PROCESS_STATE_OCCURRENCE, ProcessState.FINISHED);
+    createOrUpdate(curator, datasetKey, PROCESS_STATE_CHECKLIST, ProcessState.FINISHED);
+    createOrUpdate(curator, datasetKey, PROCESS_STATE_SAMPLE, ProcessState.FINISHED);
   }
 
   protected void failed(UUID datasetKey) {
@@ -187,7 +237,7 @@ public abstract class DownloadCrawlConsumer extends CrawlConsumer {
       publisher.send(createFinishedMessage(crawlJob));
     } catch (IOException e) {
       LOG.error(
-          "Failed to send download finished message for crawl [{}]", crawlJob.getDatasetKey(), e);
+        "Failed to send download finished message for crawl [{}]", crawlJob.getDatasetKey(), e);
     }
     // The crawl finished normally, processing still to run
     createOrUpdate(curator, datasetKey, FINISHED_REASON, FinishReason.NORMAL);
@@ -200,7 +250,7 @@ public abstract class DownloadCrawlConsumer extends CrawlConsumer {
    * "download finished" message is published.
    */
   protected void afterSuccessfulDownload(UUID datasetKey, CrawlJob crawlJob, File localFile)
-      throws IOException {}
+    throws IOException {}
 
   protected abstract String getSuffix();
 

--- a/crawler-cli/src/test/java/org/gbif/crawler/common/DownloadCrawlConsumerLinkingTest.java
+++ b/crawler-cli/src/test/java/org/gbif/crawler/common/DownloadCrawlConsumerLinkingTest.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gbif.crawler.common;
+
+import org.gbif.api.model.crawler.CrawlJob;
+import org.gbif.api.model.crawler.ProcessState;
+import org.gbif.api.vocabulary.EndpointType;
+import org.gbif.common.messaging.api.messages.DatasetBasedMessage;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.UUID;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.TestingServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.gbif.crawler.constants.CrawlerNodePaths.FINISHED_REASON;
+import static org.gbif.crawler.constants.CrawlerNodePaths.PROCESS_STATE_CHECKLIST;
+import static org.gbif.crawler.constants.CrawlerNodePaths.PROCESS_STATE_OCCURRENCE;
+import static org.gbif.crawler.constants.CrawlerNodePaths.PROCESS_STATE_SAMPLE;
+import static org.gbif.crawler.constants.CrawlerNodePaths.getCrawlInfoPath;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers the duplicate/concurrent-attempt handling in {@link DownloadCrawlConsumer}: a second run
+ * processing the same crawl attempt must not re-trigger downstream processing (no {@code
+ * FileAlreadyExistsException} stack trace, no double "download finished" message), and must not
+ * guess at a {@code FINISHED_REASON} it can't actually know.
+ *
+ * <p>This intentionally does not exercise {@link DownloadCrawlConsumer#crawl} end to end (that
+ * needs a real HTTP download, see the disabled, manual {@link DownloadCrawlConsumerTest}) - it
+ * tests the two extracted methods directly against a real embedded ZooKeeper.
+ */
+public class DownloadCrawlConsumerLinkingTest {
+
+  private static TestingServer zkServer;
+  private static CuratorFramework curator;
+
+  @TempDir File archiveRepository;
+
+  private TestDownloadCrawlConsumer consumer;
+
+  @BeforeAll
+  public static void setupZk() throws Exception {
+    zkServer = new TestingServer();
+    curator =
+      CuratorFrameworkFactory.builder()
+        .connectString(zkServer.getConnectString())
+        .namespace("crawler-linking-test")
+        .retryPolicy(new RetryOneTime(100))
+        .build();
+    curator.start();
+  }
+
+  @AfterAll
+  public static void tearDownZk() throws IOException {
+    curator.close();
+    zkServer.stop();
+  }
+
+  @BeforeEach
+  public void setup() {
+    consumer = new TestDownloadCrawlConsumer(curator, archiveRepository);
+  }
+
+  @Test
+  public void testLinkAttemptFileCreatesNewLink() throws Exception {
+    UUID datasetKey = UUID.randomUUID();
+    CrawlJob crawlJob = testCrawlJob(datasetKey);
+    File localFile = downloadedFile(datasetKey);
+
+    boolean linked = consumer.linkAttemptFile(archiveRepository, datasetKey, crawlJob, localFile);
+
+    assertTrue(linked);
+    assertTrue(new File(archiveRepository, datasetKey + ".1.suffix").exists());
+  }
+
+  @Test
+  public void testLinkAttemptFileDetectsDuplicate() throws Exception {
+    UUID datasetKey = UUID.randomUUID();
+    CrawlJob crawlJob = testCrawlJob(datasetKey);
+    File localFile = downloadedFile(datasetKey);
+
+    assertTrue(consumer.linkAttemptFile(archiveRepository, datasetKey, crawlJob, localFile));
+    // Simulates a second, concurrent run processing the exact same attempt.
+    boolean linkedAgain = consumer.linkAttemptFile(archiveRepository, datasetKey, crawlJob, localFile);
+
+    assertFalse(linkedAgain);
+  }
+
+  @Test
+  public void testDuplicateAttemptMarksFinishedWithoutWritingFinishReason() throws Exception {
+    UUID datasetKey = UUID.randomUUID();
+    CrawlJob crawlJob = testCrawlJob(datasetKey);
+
+    consumer.duplicateAttempt(datasetKey, crawlJob);
+
+    assertEquals(ProcessState.FINISHED, readProcessState(datasetKey, PROCESS_STATE_OCCURRENCE));
+    assertEquals(ProcessState.FINISHED, readProcessState(datasetKey, PROCESS_STATE_CHECKLIST));
+    assertEquals(ProcessState.FINISHED, readProcessState(datasetKey, PROCESS_STATE_SAMPLE));
+    // Deliberately not written - see duplicateAttempt()'s javadoc: we can't tell whether we're
+    // racing ahead of or behind the genuine run, so we mustn't guess a reason for it.
+    assertNull(curator.checkExists().forPath(getCrawlInfoPath(datasetKey, FINISHED_REASON)));
+  }
+
+  private static CrawlJob testCrawlJob(UUID datasetKey) {
+    return new CrawlJob(
+      datasetKey, EndpointType.DWC_ARCHIVE, URI.create("http://example.org/archive.zip"), 1, null);
+  }
+
+  private File downloadedFile(UUID datasetKey) throws IOException {
+    File localFile = new File(archiveRepository, datasetKey + ".suffix");
+    Files.write(localFile.toPath(), "content".getBytes(StandardCharsets.UTF_8));
+    return localFile;
+  }
+
+  private static ProcessState readProcessState(UUID datasetKey, String subPath) throws Exception {
+    byte[] data = curator.getData().forPath(getCrawlInfoPath(datasetKey, subPath));
+    return ProcessState.valueOf(new String(data, StandardCharsets.UTF_8));
+  }
+
+  /** Minimal concrete subclass with no network dependency, exposing the methods under test. */
+  private static class TestDownloadCrawlConsumer extends DownloadCrawlConsumer {
+    TestDownloadCrawlConsumer(CuratorFramework curator, File archiveRepository) {
+      super(curator, null, archiveRepository, 1000);
+    }
+
+    @Override
+    protected DatasetBasedMessage createFinishedMessage(CrawlJob crawlJob) {
+      return null;
+    }
+
+    @Override
+    protected String getSuffix() {
+      return ".suffix";
+    }
+
+    @Override
+    protected File getArchiveDirectory(File archiveRepository, UUID datasetKey) {
+      return archiveRepository;
+    }
+  }
+}


### PR DESCRIPTION
- Better log warning whenever a concurrency issue is happening
- Duplicate detection, through instead of setting FinishedReason = Abort, we do not set it at all, to avoid overriding the finish reason of the other concurrent runner which would write it as success.